### PR TITLE
feat: add binding lookup interface for custom functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 bin
 obj
 *.user
+
+# claude code
+CLAUDE.md
+thoughts/

--- a/src/Jsonata.Net.Native.Tests/BindingLookupTests.cs
+++ b/src/Jsonata.Net.Native.Tests/BindingLookupTests.cs
@@ -1,0 +1,108 @@
+using Jsonata.Net.Native;
+using Jsonata.Net.Native.Eval;
+using Jsonata.Net.Native.Json;
+using NUnit.Framework;
+
+namespace Jsonata.Net.Native.Tests
+{
+    public sealed class BindingLookupTests
+    {
+        [Test]
+        public void CanLookupBoundVariable()
+        {
+            EvaluationEnvironment env = new EvaluationEnvironment();
+            env.BindFunction("getVar", GetVariable);
+            env.BindValue("myVar", new JValue("test value"));
+
+            JsonataQuery query = new JsonataQuery("$getVar()");
+            JToken result = query.Eval(JValue.CreateNull(), env);
+
+            Assert.AreEqual("test value", (string)result);
+        }
+
+        [Test]
+        public void ReturnsUndefinedWhenVariableNotBound()
+        {
+            EvaluationEnvironment env = new EvaluationEnvironment();
+            env.BindFunction("getVar", GetVariable);
+
+            JsonataQuery query = new JsonataQuery("$getVar()");
+            JToken result = query.Eval(JValue.CreateNull(), env);
+
+            Assert.AreEqual(JTokenType.Undefined, result.Type);
+        }
+
+        [Test]
+        public void CanCombineWithRegularParameters()
+        {
+            EvaluationEnvironment env = new EvaluationEnvironment();
+            env.BindFunction("concat", ConcatWithVariable);
+            env.BindValue("suffix", new JValue(" world"));
+
+            JsonataQuery query = new JsonataQuery("$concat('hello')");
+            JToken result = query.Eval(JValue.CreateNull(), env);
+
+            Assert.AreEqual("hello world", (string)result);
+        }
+
+        [Test]
+        public void CanAccessMultipleVariables()
+        {
+            EvaluationEnvironment env = new EvaluationEnvironment();
+            env.BindFunction("fullName", BuildFullName);
+            env.BindValue("firstName", new JValue("John"));
+            env.BindValue("lastName", new JValue("Doe"));
+
+            JsonataQuery query = new JsonataQuery("$fullName()");
+            JToken result = query.Eval(JValue.CreateNull(), env);
+
+            Assert.AreEqual("John Doe", (string)result);
+        }
+
+        [Test]
+        public void ErrorMessageExcludesInjectedParameterFromCount()
+        {
+            EvaluationEnvironment env = new EvaluationEnvironment();
+            env.BindFunction("test", FunctionRequiringOneArg);
+
+            JsonataQuery query = new JsonataQuery("$test()");
+            JsonataException? ex = Assert.Throws<JsonataException>(() =>
+                query.Eval(JValue.CreateNull(), env));
+
+            Assert.AreEqual("T0410", ex!.Code);
+            Assert.That(ex!.Message, Does.Contain("requires 1"));
+        }
+
+        public static JToken GetVariable(IBindingLookup lookup)
+        {
+            return lookup.Lookup("myVar");
+        }
+
+        public static JToken ConcatWithVariable(string prefix, IBindingLookup lookup)
+        {
+            JToken suffix = lookup.Lookup("suffix");
+            if (suffix.Type == JTokenType.String)
+            {
+                return new JValue(prefix + (string)suffix);
+            }
+            return new JValue(prefix);
+        }
+
+        public static JToken BuildFullName(IBindingLookup lookup)
+        {
+            JToken firstName = lookup.Lookup("firstName");
+            JToken lastName = lookup.Lookup("lastName");
+
+            if (firstName.Type == JTokenType.String && lastName.Type == JTokenType.String)
+            {
+                return new JValue($"{(string)firstName} {(string)lastName}");
+            }
+            return EvalProcessor.UNDEFINED;
+        }
+
+        public static JToken FunctionRequiringOneArg(string required, IBindingLookup lookup)
+        {
+            return new JValue("result");
+        }
+    }
+}

--- a/src/Jsonata.Net.Native/Eval/Attributes.cs
+++ b/src/Jsonata.Net.Native/Eval/Attributes.cs
@@ -40,7 +40,6 @@ namespace Jsonata.Net.Native.Eval
         }
     }
 
-    //provides support for builtin functions that require EvaluationSupplement
     [AttributeUsage(AttributeTargets.Parameter)]
     internal sealed class EvalSupplementArgumentAttribute : Attribute
     {

--- a/src/Jsonata.Net.Native/EvaluationEnvironment.cs
+++ b/src/Jsonata.Net.Native/EvaluationEnvironment.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace Jsonata.Net.Native
 {
-    public sealed class EvaluationEnvironment
+    public sealed class EvaluationEnvironment : IBindingLookup
     {
         public static readonly EvaluationEnvironment DefaultEnvironment;
 
@@ -104,6 +104,8 @@ namespace Jsonata.Net.Native
                 return EvalProcessor.UNDEFINED;
             }
         }
+
+        JToken IBindingLookup.Lookup(string name) => this.Lookup(name);
 
         internal EvaluationSupplement GetEvaluationSupplement()
         {

--- a/src/Jsonata.Net.Native/IBindingLookup.cs
+++ b/src/Jsonata.Net.Native/IBindingLookup.cs
@@ -1,0 +1,24 @@
+using Jsonata.Net.Native.Json;
+
+namespace Jsonata.Net.Native
+{
+    /// <summary>
+    /// Provides access to JSONata bindings (variables and functions) during evaluation.
+    /// Custom built-in functions can receive this interface via the
+    /// [BindingLookupArgument] attribute to access bindings in the evaluation environment.
+    /// </summary>
+    public interface IBindingLookup
+    {
+        /// <summary>
+        /// Looks up a binding by name in the evaluation environment.
+        /// Searches the current environment and parent environments
+        /// hierarchically until found or all environments exhausted.
+        /// Can return variables, functions, or any bound JToken value.
+        /// </summary>
+        /// <param name="name">The binding name to look up (without '$' prefix for variables/functions)</param>
+        /// <returns>
+        /// The JToken value bound to the name (can be a value, function, or UNDEFINED if not found)
+        /// </returns>
+        JToken Lookup(string name);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new public interface `IBindingLookup` that allows custom built-in functions to access JSONata bindings (variables and functions) during evaluation.

## Use Case

This enables advanced scenarios where custom functions need to interact with the evaluation context. For example, when working with complex data structures like Draft.js that define their own variable systems, custom functions can now map those internal variables to JSONata bindings dynamically.

## Usage Example

```csharp
public static JToken ProcessTemplate(string template, IBindingLookup lookup)
{
    JToken header = lookup.Lookup("headerText");
    return new JValue($"{header}: {template}");
}

env.BindFunction("process", ProcessTemplate);
env.BindValue("headerText", new JValue("Title"));
```

## Implementation

- New `IBindingLookup` interface with `Lookup(string name)` method
- Parameters of type `IBindingLookup` are automatically detected and injected
- No attributes required - simply declare the parameter with the interface type
- Injected parameters don't count toward function argument requirements

## Breaking Changes

None - this is a purely additive feature.